### PR TITLE
Gestion correcte des doublons

### DIFF
--- a/legi/sql/migrations.sql
+++ b/legi/sql/migrations.sql
@@ -25,3 +25,10 @@ CREATE VIEW textes_versions_brutes_view AS
       FROM textes_versions a
  LEFT JOIN textes_versions_brutes b
         ON b.id = a.id AND b.cid = a.cid AND b.dossier = a.dossier AND b.mtime = a.mtime;
+
+-- migration #2
+DELETE FROM db_meta WHERE key = 'last_update';
+DELETE FROM textes; DELETE FROM textes_structs; DELETE FROM textes_versions;
+DELETE FROM sections; DELETE FROM articles; DELETE FROM sommaires; DELETE FROM liens;
+DELETE FROM duplicate_files; DELETE FROM textes_versions_brutes;
+ALTER TABLE duplicate_files ADD COLUMN data text NOT NULL;

--- a/legi/sql/schema.sql
+++ b/legi/sql/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE db_meta
 , value blob
 );
 
-INSERT INTO db_meta (key, value) VALUES ('schema_version', 1);
+INSERT INTO db_meta (key, value) VALUES ('schema_version', 2);
 
 CREATE TABLE textes
 ( id integer primary key not null
@@ -116,6 +116,7 @@ CREATE TABLE duplicate_files
 , cid char(20) not null
 , dossier text not null
 , mtime int not null
+, data text not null
 , other_cid char(20) not null
 , other_dossier text not null
 , other_mtime int not null

--- a/legi/tar2sqlite.py
+++ b/legi/tar2sqlite.py
@@ -79,18 +79,19 @@ def suppress(get_table, db, liste_suppression):
                        AND _source = 'struct/' || ?
                 """, (text_cid, text_id))
                 count(deletions, 'sommaires', db.changes())
-            # And remove the file from the duplicates list if it was in there
+            # And delete the associated row in textes_versions_brutes if it exists
+            if table == 'textes_versions':
+                db.run("DELETE FROM textes_versions_brutes WHERE id = ?", (text_id,))
+                count(deletions, 'textes_versions_brutes', db.changes())
+        else:
+            # Remove the file from the duplicates table if it was in there
             db.run("""
                 DELETE FROM duplicate_files
                  WHERE dossier = ?
                    AND cid = ?
                    AND id = ?
-            """.format(table), (parts[3], text_cid, text_id))
+            """, (parts[3], text_cid, text_id))
             count(deletions, 'duplicate_files', db.changes())
-            # And delete the associated row in textes_versions_brutes if it exists
-            if table == 'textes_versions':
-                db.run("DELETE FROM textes_versions_brutes WHERE id = ?", (text_id,))
-                count(deletions, 'textes_versions_brutes', db.changes())
     total = sum(deletions.values())
     print('deleted', total, 'rows based on liste_suppression_legi.dat:',
           json.dumps(deletions, sort_keys=True))


### PR DESCRIPTION
La solution de legi.py au problème des fichiers doublons dans les archives LEGI a toujours été de prendre les données dans le fichier le plus récent (en se basant sur le `mtime`), et jusqu'à présent les fichiers plus anciens n'étaient pas conservés. Ce dernier point pose problème, car quand le fichier le plus récent est supprimé dans une version ultérieure de la base, sans que le(s) fichier(s) plus ancien(s) soi(en)t également supprimé(s), alors la BDD produite par legi.py n'est plus complète.

Les changements apportés par cette Pull Request corrige ce problème de la façon suivante :

- les données des fichiers doublons sont enregistrées
- quand le fichier le plus récent est supprimé ses données sont remplacées par celles du deuxième fichier le plus récent, si celui-ci existe évidemment

La mise en pratique de ce nouveau fonctionnement nécessite de recréer la BDD depuis le début, c'est pourquoi la migration automatique fait le vide.