### PR TITLE
Nettoyage HTML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ branches:
   only:
     - master
 
+addons:
+  apt:
+    packages:
+      - libarchive13
+
 install:
   - sqlite3 --version
   - pip install tox

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ Le module `normalize` corrige les titres de textes qui ne sont pas parfaitement
 La "factorisation" connecte entre elles les différentes version d'un même texte.
 La base LEGI n'a pas d'identifiant qui remplisse réellement ce rôle.
 
+### Nettoyage des contenus
+
+Le module `html` permet de nettoyer les contenus des textes. Il supprime :
+
+- les espaces redondantes (*whitespace collapse*), sauf à l'intérieur des `<pre>`
+- les attributs inutiles, par exemple `id` et `dir="ltr"`
+- les éléments inutiles, par exemple un `<span>` sans attributs
+- les éléments vides, sauf `<td>` et `<th>`
+
+En février 2018 il détecte 78 millions de caractères inutiles dans LEGI.
+
+Cette fonctionnalité n'est pas activée par défaut car elle est « destructrice »
+et récente. Vous pouvez nettoyer tout l'HTML d'une base en exécutant la commande
+`python -m legi.html clean legi.sqlite` (les modifications ne sont enregistrées
+que si vous entrez `y` à la fin).
+
 ### Détection d'anomalies
 
 Le module `anomalies` est conçu pour détecter les incohérences dans les données afin de les signaler à la DILA. Le résultat est visible sur [anomalies.legilibre.fr][anomalies]. (`cron/anomalies-cron.sh` est le script qui génère ce mini-site.)

--- a/legi/html.py
+++ b/legi/html.py
@@ -13,7 +13,7 @@ import json
 from lxml import etree
 from maps import FrozenMap, namedfrozen
 
-from .utils import connect_db, multispace_re
+from .utils import connect_db, spaces_re
 
 
 # An immutable type representing the opening of an HTML element
@@ -119,8 +119,9 @@ class HTMLCleaner(object):
         if not text.strip():
             return
         # Collapse spaces, unless we're inside a <pre>
+        # https://www.w3.org/TR/css-text-3/#white-space-processing
         if self.tag_stack[-1].style['.collapse-spaces']:
-            text = multispace_re.sub(' ', text)
+            text = spaces_re.sub(' ', text)
         # Add to output
         self.out.append(text)
 

--- a/legi/html.py
+++ b/legi/html.py
@@ -12,7 +12,6 @@ from difflib import ndiff
 import json
 import re
 from xml.parsers import expat
-from xml.sax.saxutils import escape, quoteattr, unescape
 
 from lxml import etree
 
@@ -74,6 +73,36 @@ USELESS_WITHOUT_ATTRIBUTES = {'font', 'span'}
 # http://w3c.github.io/html/syntax.html#void-elements
 # Only two void tags are actually used in LEGI
 VOID_ELEMENTS = {'br', 'hr'}
+
+
+ESCAPE_TABLE = [('&', '&amp;'), ('<', '&lt;'), ('>', '&gt;')]
+ESCAPE_ATTR_TABLE = ESCAPE_TABLE + [('"', '&#34;')]
+
+
+def escape(s, table=ESCAPE_TABLE):
+    """Escape &, <, and > in a string of data.
+    """
+    for c, r in table:
+        if c in s:
+            s = s.replace(c, r)
+    return s
+
+
+def unescape(s):
+    """Unescape &amp;, &lt;, and &gt; in a string of data.
+    """
+    if '&' not in s:
+        return s
+    return s.replace('&gt;', '>').replace('&lt;', '<').replace('&amp;', '&')
+
+
+def quoteattr(s, table=ESCAPE_ATTR_TABLE):
+    """Escape and quote an attribute value.
+    """
+    for c, r in table:
+        if c in s:
+            s = s.replace(c, r)
+    return '"%s"' % s
 
 
 bad_space_re = re.compile(r"[dl]['’] \w| [,.]", re.I | re.U)

--- a/legi/html.py
+++ b/legi/html.py
@@ -61,7 +61,7 @@ DEFAULT_STYLE = FrozenMap({
 })
 
 # Set of elements that should not be dropped even if they're completely empty
-KEEP_EMPTY = {'td', 'th'}
+KEEP_EMPTY = {'body', 'td', 'th'}
 
 # A fake StartTag which holds the default styles
 INVISIBLE_ROOT_TAG = StartTag(None, None, DEFAULT_STYLE, True)
@@ -255,9 +255,9 @@ def clean_html(html):
     p.StartElementHandler = cleaner.start
     p.EndElementHandler = cleaner.end
     p.CharacterDataHandler = cleaner.data
-    p.Parse('<root>')
+    p.Parse('<body>')
     p.Parse(html)
-    p.Parse('</root>', 1)
+    p.Parse('</body>', 1)
     return cleaner.close()[6:-7]
 
 

--- a/legi/html.py
+++ b/legi/html.py
@@ -77,7 +77,7 @@ USELESS_WITHOUT_ATTRIBUTES = {'font', 'span'}
 VOID_ELEMENTS = {'br', 'hr'}
 
 
-bad_space_re = re.compile(r"[dl]['’] \w| [,.]", re.U)
+bad_space_re = re.compile(r"[dl]['’] \w| [,.]", re.I | re.U)
 
 
 def drop_bad_space(m):

--- a/legi/html.py
+++ b/legi/html.py
@@ -97,6 +97,7 @@ class HTMLCleaner(object):
 
     def __init__(self):
         self.drop_next_space = True
+        self.drop_line_breaks = True
         self.last_collapsible_node = None
         self.out = []
         self.tag_stack = [INVISIBLE_ROOT_TAG]
@@ -137,9 +138,11 @@ class HTMLCleaner(object):
         if tag == 'pre':
             new_styles['.collapse-spaces'] = False
         styles = FrozenMap(parent_styles, **new_styles) if new_styles else parent_styles
+        if self.drop_line_breaks and ''.join(self.text_chunks).strip(ASCII_SPACES):
+            self.drop_line_breaks = False
         dropped = (
             not attrs_str and tag in USELESS_WITHOUT_ATTRIBUTES or
-            len(self.out) == 1 and tag == 'br'
+            tag == 'br' and self.drop_line_breaks
         )
         start_tag = StartTag(tag, void, styles, dropped)
         if not dropped:
@@ -230,6 +233,8 @@ class HTMLCleaner(object):
             self.last_collapsible_node = None
         # Disable dropping the next space
         self.drop_next_space = False
+        # Stop dropping <br> tags
+        self.drop_line_breaks = False
         # Add to output
         self.out.append(escape(text))
 

--- a/legi/html.py
+++ b/legi/html.py
@@ -23,11 +23,14 @@ except ImportError:
     print('[warning] tqdm is not installed, the progress bar is disabled')
     tqdm = lambda x: x
 
-from .utils import connect_db, group_by_2, input, spaces_re
+from .utils import connect_db, group_by_2, input, ascii_spaces_re
 
 
 # An immutable type representing the opening of an HTML element
 StartTag = namedtuple('StartTag', 'tag void style dropped')
+
+# String of ascii whitespace
+ASCII_SPACES = ' \t\n\r\f\v'
 
 # Map of color names to hexadecimal values
 COLORS_MAP = {
@@ -147,12 +150,12 @@ class HTMLCleaner(object):
     def handle_text(self):
         text = ''.join(self.text_chunks)
         self.text_chunks = []
-        if not text.strip():
+        if not text.strip(ASCII_SPACES):
             return
         # Collapse spaces, unless we're inside a <pre>
         # https://www.w3.org/TR/css-text-3/#white-space-processing
         if self.tag_stack[-1].style['.collapse-spaces']:
-            text = spaces_re.sub(' ', text)
+            text = ascii_spaces_re.sub(' ', text)
             # French-specific dropping of bad spaces, e.g. "l' article" → "l'article"
             text = bad_space_re.sub(drop_bad_space, text)
         # Add to output
@@ -163,7 +166,7 @@ class HTMLCleaner(object):
             self.handle_text()
         # Join the output into a single string, then reset the parser before
         # returning so that it can be reused
-        r = ''.join(self.out).rstrip()
+        r = ''.join(self.out)
         self.__init__()
         return r
 

--- a/legi/html.py
+++ b/legi/html.py
@@ -161,7 +161,7 @@ class HTMLCleaner(object):
                 # Enable dropping the next space
                 self.drop_next_space = True
             # Add start tag to output
-            self.out.append('<' + tag + attrs_str + (' />' if void else '>'))
+            self.out.append('<' + tag + attrs_str + ('/>' if void else '>'))
         self.tag_stack.append(start_tag)
 
     def end(self, tag):

--- a/legi/html.py
+++ b/legi/html.py
@@ -239,6 +239,18 @@ class HTMLCleaner(object):
         # https://www.w3.org/TR/css-text-3/#white-space-processing
         if current_tag.style['.collapse-spaces']:
             text = ascii_spaces_re.sub(' ', text)
+            # Handle spaces around closing tags
+            i = self.last_trimmable_node
+            if i and not next_tag and self.out[i - 1][:2] == '</':
+                # `</i> foo </b>bar` → `</i> foo</b> bar`
+                trimmed = self.out[i][:-1]
+                if trimmed:
+                    self.out[i] = trimmed
+                else:
+                    self.out.pop(i)
+                i = self.last_trimmable_node = None
+                if text[0] != ' ':
+                    text = ' ' + text
             # Drop leading space if the previous text node has a trailing space
             # or if we're at the beginning of a "segment"
             if text[0] == ' ' and (self.last_trimmable_node or self.at_segment_start):

--- a/legi/html.py
+++ b/legi/html.py
@@ -292,12 +292,12 @@ class HTMLCleaner(object):
         return r
 
 
-def clean_html(html):
+def clean_html(html, cleaner=HTMLCleaner()):
     """Returns cleaned HTML
 
-    This function is a simple wrapper around the HTMLCleaner class.
+    Warning: this function is not thread safe unless you provide your own
+    thread-local `cleaner` instance.
     """
-    cleaner = HTMLCleaner()
     p = expat.ParserCreate()
     p.buffer_text = True
     p.ordered_attributes = True

--- a/legi/html.py
+++ b/legi/html.py
@@ -61,7 +61,7 @@ DEFAULT_STYLE = FrozenMap({
 })
 
 # Set of elements that should not be dropped even if they're completely empty
-KEEP_EMPTY = {'body', 'td', 'th'}
+KEEP_EMPTY = {'body', 'br', 'hr', 'td', 'th'}
 
 # A fake StartTag which holds the default styles
 INVISIBLE_ROOT_TAG = StartTag(None, None, DEFAULT_STYLE, True)

--- a/legi/html.py
+++ b/legi/html.py
@@ -105,7 +105,10 @@ class HTMLCleaner(object):
         if tag == 'pre':
             new_styles['.collapse-spaces'] = False
         styles = FrozenMap(parent_styles, **new_styles) if new_styles else parent_styles
-        dropped = not attrs_str and tag in USELESS_WITHOUT_ATTRIBUTES
+        dropped = (
+            not attrs_str and tag in USELESS_WITHOUT_ATTRIBUTES or
+            len(self.out) == 1 and tag == 'br'
+        )
         self.tag_stack.append(StartTag(tag, void, styles, dropped))
         if not dropped:
             self.out.append('<' + tag + attrs_str + (' />' if void else '>'))

--- a/legi/html.py
+++ b/legi/html.py
@@ -149,9 +149,9 @@ class HTMLCleaner(object):
                     continue
                 # Normalize the value
                 v = v.strip()
-                if k.endswith('color'):
+                if k[-5:] == 'color':
                     v = v.lower()
-                    if v.startswith('rgb('):
+                    if v[:4] == 'rgb(':
                         v = '#%02x%02x%02x' % tuple(int(s.strip()) for s in v[4:-1].split(','))
                     elif v.__len__() == 6 and v.isdigit():
                         v = '#' + v

--- a/legi/html.py
+++ b/legi/html.py
@@ -1,0 +1,95 @@
+# encoding: utf8
+
+"""
+This module handles the HTML provided in LEGI.
+"""
+
+from __future__ import division, print_function, unicode_literals
+
+from argparse import ArgumentParser
+import json
+
+from lxml import etree
+
+from .utils import connect_db
+
+
+class StatsCollector(object):
+    """Collects stats about the HTML tags and attributes used in LEGI
+    """
+
+    def __init__(self):
+        self.stats = {}
+
+    def start(self, tag, attrs):
+        try:
+            tag_stats = self.stats[tag]
+        except KeyError:
+            tag_stats = self.stats[tag] = {'count': 0, 'attrs': {}}
+        tag_stats['count'] += 1
+        tag_stats_attrs = tag_stats['attrs']
+        for attr in attrs.items():
+            if attr[0] == 'id':
+                attr = attr[0]
+            elif attr[1].lstrip('-').isdigit():
+                attr = "%s = <integer>" % attr[0]
+            elif attr[1][-1:] == '%' and attr[1][:-1].isdigit():
+                attr = "%s = <percentage>" % attr[0]
+            else:
+                attr = "%s = %s" % attr
+            try:
+                tag_stats_attrs[attr] += 1
+            except KeyError:
+                tag_stats_attrs[attr] = 1
+
+    def comment(self):
+        self.start('<!--', ())
+
+    def close(self):
+        r = self.stats
+        self.__init__()
+        return r
+
+
+def main(db):
+    parser = etree.XMLParser(target=StatsCollector())
+    parser.feed('<root>')
+    # Articles
+    q = db.all("""
+        SELECT id, bloc_textuel, nota
+          FROM articles
+    """)
+    for article_id, bloc_textuel, nota in q:
+        if bloc_textuel:
+            parser.feed(bloc_textuel)
+        if nota:
+            parser.feed(nota)
+    # Textes
+    q = db.all("""
+        SELECT id, visas, signataires, tp, nota, abro, rect
+          FROM textes_versions
+    """)
+    for row in q:
+        for text in row[1:]:
+            if text:
+                parser.feed(text)
+    # Result
+    parser.feed('</root>')
+    stats = parser.close()
+    if stats['root']['count'] == 1:
+        del stats['root']
+    else:
+        stats['root']['count'] -= 1
+    print(json.dumps(stats, indent=4, sort_keys=True))
+
+
+if __name__ == '__main__':
+    p = ArgumentParser()
+    p.add_argument('db')
+    args = p.parse_args()
+
+    db = connect_db(args.db)
+    try:
+        main(db)
+    except KeyboardInterrupt:
+        pass

--- a/legi/html.py
+++ b/legi/html.py
@@ -8,11 +8,12 @@ from __future__ import division, print_function, unicode_literals
 
 from argparse import ArgumentParser
 from cgi import escape
+from collections import namedtuple
 import json
 import re
 
 from lxml import etree
-from maps import FrozenMap, namedfrozen
+from maps import FrozenMap
 
 try:
     from tqdm import tqdm
@@ -24,7 +25,7 @@ from .utils import connect_db, input, spaces_re
 
 
 # An immutable type representing the opening of an HTML element
-StartTag = namedfrozen(str('StartTag'), ['tag', 'void', 'style', 'dropped'])
+StartTag = namedtuple('StartTag', 'tag void style dropped')
 
 # Map of color names to hexadecimal values
 COLORS_MAP = {

--- a/legi/html.py
+++ b/legi/html.py
@@ -84,7 +84,7 @@ def drop_bad_space(m):
 
 
 def is_start_of(s, tag):
-    x = len(tag)
+    x = tag.__len__()
     return s[0] == '<' and s[1:x+1] == tag and s[x+1] in ' >' and s[-2] != '/'
 
 
@@ -124,7 +124,7 @@ class HTMLCleaner(object):
                     v = v.lower()
                     if v.startswith('rgb('):
                         v = '#%02x%02x%02x' % tuple(int(s.strip()) for s in v[4:-1].split(','))
-                    elif len(v) == 6 and v.isdigit():
+                    elif v.__len__() == 6 and v.isdigit():
                         v = '#' + v
                     else:
                         v = COLORS_MAP.get(v, v)
@@ -174,7 +174,7 @@ class HTMLCleaner(object):
         collapsed = False
         if is_start_of(self.out[-1], tag):
             if not ''.join(self.text_chunks).strip(ASCII_SPACES):
-                tag_has_attributes = len(self.out[-1]) > len(tag) + 2
+                tag_has_attributes = self.out[-1].__len__() > tag.__len__() + 2
                 if tag_has_attributes or tag in KEEP_EMPTY:
                     # Drop the whitespace chunks, if any
                     self.text_chunks = []
@@ -233,7 +233,7 @@ class HTMLCleaner(object):
             # French-specific dropping of bad spaces, e.g. "l' article" → "l'article"
             text = bad_space_re.sub(drop_bad_space, text)
             # Update the collapsible node index
-            self.last_collapsible_node = len(self.out)
+            self.last_collapsible_node = self.out.__len__()
         else:
             # Reset the collapsible node index
             self.last_collapsible_node = None
@@ -290,11 +290,12 @@ def clean_all_html_in_db(db, check=True):
                 continue
             update[col] = html_c
             stats['cleaned'] += 1
-            stats['delta'] += len(html_c) - len(html)
+            delta = html_c.__len__() - html.__len__()
+            stats['delta'] += delta
             if not check:
                 continue
             # Check lengths
-            if len(html_c) > len(html):
+            if delta > 0:
                 print()
                 print("=" * 70)
                 print((

--- a/legi/html.py
+++ b/legi/html.py
@@ -136,7 +136,7 @@ class HTMLCleaner(object):
             # French-specific dropping of bad spaces, e.g. "l' article" → "l'article"
             text = bad_space_re.sub(drop_bad_space, text)
         # Add to output
-        self.out.append(text)
+        self.out.append(escape(text))
 
     def close(self):
         # Join the output into a single string, then reset the parser before

--- a/legi/html.py
+++ b/legi/html.py
@@ -9,6 +9,7 @@ from __future__ import division, print_function, unicode_literals
 from argparse import ArgumentParser
 from cgi import escape
 import json
+import re
 
 from lxml import etree
 from maps import FrozenMap, namedfrozen
@@ -51,6 +52,13 @@ USELESS_WITHOUT_ATTRIBUTES = {'font', 'span'}
 # http://w3c.github.io/html/syntax.html#void-elements
 # Only two void tags are actually used in LEGI
 VOID_ELEMENTS = {'br', 'hr'}
+
+
+bad_space_re = re.compile(r"[dl]['’] \w| [,.]", re.U)
+
+
+def drop_bad_space(m):
+    return m.group(0).replace(' ', '')
 
 
 class HTMLCleaner(object):
@@ -122,6 +130,8 @@ class HTMLCleaner(object):
         # https://www.w3.org/TR/css-text-3/#white-space-processing
         if self.tag_stack[-1].style['.collapse-spaces']:
             text = spaces_re.sub(' ', text)
+            # French-specific dropping of bad spaces, e.g. "l' article" → "l'article"
+            text = bad_space_re.sub(drop_bad_space, text)
         # Add to output
         self.out.append(text)
 

--- a/legi/html.py
+++ b/legi/html.py
@@ -7,11 +7,11 @@ This module handles the HTML provided in LEGI.
 from __future__ import division, print_function, unicode_literals
 
 from argparse import ArgumentParser
-from cgi import escape
 from collections import namedtuple
 import json
 import re
 from xml.parsers import expat
+from xml.sax.saxutils import escape, quoteattr
 
 from lxml import etree
 from maps import FrozenMap
@@ -112,7 +112,7 @@ class HTMLCleaner(object):
             if parent_style:
                 new_styles[k] = v
             # Add to output
-            attrs_str += ' %s="%s"' % (k, escape(v))
+            attrs_str += ' %s=%s' % (k, quoteattr(v))
         if tag == 'pre':
             new_styles['.collapse-spaces'] = False
         styles = FrozenMap(parent_styles, **new_styles) if new_styles else parent_styles

--- a/legi/html.py
+++ b/legi/html.py
@@ -15,7 +15,6 @@ from xml.parsers import expat
 from xml.sax.saxutils import escape, quoteattr, unescape
 
 from lxml import etree
-from maps import FrozenMap
 
 try:
     from tqdm import tqdm
@@ -50,7 +49,7 @@ COLORS_MAP = {
 }
 
 # Default styles, used to detect redundant attributes
-DEFAULT_STYLE = FrozenMap({
+DEFAULT_STYLE = {
     '.collapse-spaces': True,
     'align': 'left',
     'bgcolor': '#ffffff',
@@ -58,7 +57,7 @@ DEFAULT_STYLE = FrozenMap({
     'color': '#000000',
     'dir': 'ltr',
     'valign': 'baseline',
-})
+}
 
 # Set of elements that should not be dropped even if they're completely empty
 KEEP_EMPTY = {'body', 'br', 'hr', 'td', 'th'}
@@ -137,7 +136,7 @@ class HTMLCleaner(object):
             attrs_str += ' %s=%s' % (k, quoteattr(v))
         if tag == 'pre':
             new_styles['.collapse-spaces'] = False
-        styles = FrozenMap(parent_styles, **new_styles) if new_styles else parent_styles
+        styles = dict(parent_styles, **new_styles) if new_styles else parent_styles
         if self.drop_line_breaks and ''.join(self.text_chunks).strip(ASCII_SPACES):
             self.drop_line_breaks = False
         dropped = (

--- a/legi/html.py
+++ b/legi/html.py
@@ -65,7 +65,7 @@ KEEP_EMPTY = {'body', 'br', 'hr', 'td', 'th'}
 INVISIBLE_ROOT_TAG = StartTag(None, None, DEFAULT_STYLE, True, None)
 
 # Set of attributes that should always be dropped
-USELESS_ATTRIBUTES = {'charoff', 'id'}
+USELESS_ATTRIBUTES = {'charoff', 'face', 'id'}
 
 # Set of elements that should be dropped if they don't have any attributes
 USELESS_WITHOUT_ATTRIBUTES = {'font', 'span'}

--- a/legi/html.py
+++ b/legi/html.py
@@ -89,7 +89,7 @@ class HTMLCleaner(object):
             if k.endswith('color'):
                 v = v.lower()
                 if v.startswith('rgb('):
-                    v = '#%02x%02x%02x' % [int(s.strip()) for s in v[4:-1].split(',')]
+                    v = '#%02x%02x%02x' % tuple(int(s.strip()) for s in v[4:-1].split(','))
                 elif len(v) == 6 and v.isdigit():
                     v = '#' + v
                 else:

--- a/legi/html.py
+++ b/legi/html.py
@@ -109,31 +109,33 @@ class HTMLCleaner(object):
         parent = self.tag_stack[-1]
         parent_styles = parent.style
         new_styles = {}
-        for k, v in group_by_2(attrs):
-            # Skip useless attributes
-            if k in USELESS_ATTRIBUTES:
-                continue
-            # Skip obsolete list style attribute
-            if k == 'type' and tag in {'ul', 'ol'}:
-                continue
-            # Normalize the value
-            v = v.strip()
-            if k.endswith('color'):
-                v = v.lower()
-                if v.startswith('rgb('):
-                    v = '#%02x%02x%02x' % tuple(int(s.strip()) for s in v[4:-1].split(','))
-                elif len(v) == 6 and v.isdigit():
-                    v = '#' + v
-                else:
-                    v = COLORS_MAP.get(v, v)
-            # Skip redundant styles
-            parent_style = parent_styles.get(k)
-            if parent_style == v:
-                continue
-            if parent_style:
-                new_styles[k] = v
-            # Add to output
-            attrs_str += ' %s=%s' % (k, quoteattr(v))
+        if attrs:
+            is_list_tag = tag in {'ul', 'ol'}
+            for k, v in group_by_2(attrs):
+                # Skip useless attributes
+                if k in USELESS_ATTRIBUTES:
+                    continue
+                # Skip obsolete list style attribute
+                if is_list_tag and k == 'type':
+                    continue
+                # Normalize the value
+                v = v.strip()
+                if k.endswith('color'):
+                    v = v.lower()
+                    if v.startswith('rgb('):
+                        v = '#%02x%02x%02x' % tuple(int(s.strip()) for s in v[4:-1].split(','))
+                    elif len(v) == 6 and v.isdigit():
+                        v = '#' + v
+                    else:
+                        v = COLORS_MAP.get(v, v)
+                # Skip redundant styles
+                parent_style = parent_styles.get(k)
+                if parent_style == v:
+                    continue
+                if parent_style:
+                    new_styles[k] = v
+                # Add to output
+                attrs_str += ' %s=%s' % (k, quoteattr(v))
         if tag == 'pre':
             new_styles['.collapse-spaces'] = False
         styles = dict(parent_styles, **new_styles) if new_styles else parent_styles

--- a/legi/tar2sqlite.py
+++ b/legi/tar2sqlite.py
@@ -476,11 +476,7 @@ def main():
     if not os.path.isdir(args.anomalies_dir):
         os.mkdir(args.anomalies_dir)
 
-    db = connect_db(args.db)
-    for pragma in args.pragma:
-        query = "PRAGMA " + pragma
-        result = db.one(query)
-        print("> Sent `%s` to SQLite, got `%s` as result" % (query, result))
+    db = connect_db(args.db, pragmas=args.pragma)
 
     process_links = not args.skip_links
     if args.skip_links:

--- a/legi/tar2sqlite.py
+++ b/legi/tar2sqlite.py
@@ -33,8 +33,8 @@ def count(d, k, c):
 
 
 def innerHTML(e):
-    i = len(e.tag) + 2
-    return etree.tostring(e, encoding='unicode', with_tail=False)[i:-i-1]
+    r = etree.tostring(e, encoding='unicode', with_tail=False)
+    return r[r.find('>')+1:-len(e.tag)-3]
 
 
 def scrape_tags(attrs, root, wanted_tags, unwrap=False):

--- a/legi/utils.py
+++ b/legi/utils.py
@@ -190,6 +190,17 @@ def run_migrations(db):
     return n - v
 
 
+def group_by_2(iterable):
+    iterable = iter(iterable)
+    while True:
+        a = next(iterable)
+        try:
+            b = next(iterable)
+        except StopIteration:
+            raise ValueError("iterable returned an odd number of items")
+        yield (a, b)
+
+
 nonalphanum_re = re.compile(r'[^a-z0-9]')
 
 

--- a/legi/utils.py
+++ b/legi/utils.py
@@ -220,6 +220,7 @@ def reconstruct_path(dossier, cid, sous_dossier, id):
     return '/'.join((prefix, dossier, id_to_path(cid), sous_dossier, id+'.xml'))
 
 
+multispace_re = re.compile(r' {2,}')
 nonword_re = re.compile(r'\W', re.U)
 spaces_re = re.compile(r'\s+', re.U)
 word_re = re.compile(r'\w{2,}', re.U)

--- a/legi/utils.py
+++ b/legi/utils.py
@@ -18,6 +18,8 @@ import traceback
 from unicodedata import combining, normalize
 
 
+PY2 = str is bytes
+
 input = getattr(builtins, 'raw_input', input)
 
 
@@ -191,11 +193,12 @@ def run_migrations(db):
 
 
 def group_by_2(iterable):
-    iterable = iter(iterable)
+    iterable = iterable.__iter__()
+    next = iterable.next if PY2 else iterable.__next__
     while True:
-        a = next(iterable)
+        a = next()
         try:
-            b = next(iterable)
+            b = next()
         except StopIteration:
             raise ValueError("iterable returned an odd number of items")
         yield (a, b)

--- a/legi/utils.py
+++ b/legi/utils.py
@@ -236,6 +236,7 @@ def reconstruct_path(dossier, cid, sous_dossier, id):
     return '/'.join((prefix, dossier, id_to_path(cid), sous_dossier, id+'.xml'))
 
 
+ascii_spaces_re = re.compile(r'[ \t\n\r\f\v]+')
 nonword_re = re.compile(r'\W', re.U)
 spaces_re = re.compile(r'\s+', re.U)
 word_re = re.compile(r'\w{2,}', re.U)

--- a/legi/utils.py
+++ b/legi/utils.py
@@ -225,7 +225,6 @@ def reconstruct_path(dossier, cid, sous_dossier, id):
     return '/'.join((prefix, dossier, id_to_path(cid), sous_dossier, id+'.xml'))
 
 
-multispace_re = re.compile(r' {2,}')
 nonword_re = re.compile(r'\W', re.U)
 spaces_re = re.compile(r'\s+', re.U)
 word_re = re.compile(r'\w{2,}', re.U)

--- a/legi/utils.py
+++ b/legi/utils.py
@@ -61,7 +61,7 @@ ROW_FACTORIES = {
 }
 
 
-def connect_db(address, row_factory=None, create_schema=True, update_schema=True):
+def connect_db(address, row_factory=None, create_schema=True, update_schema=True, pragmas=()):
     db = DB(address)
     db.address = address
     if row_factory:
@@ -102,6 +102,11 @@ def connect_db(address, row_factory=None, create_schema=True, update_schema=True
         r = run_migrations(db)
         if r == '!RECREATE!':
             return connect_db(address, row_factory=row_factory, create_schema=True)
+
+    for pragma in pragmas:
+        query = "PRAGMA " + pragma
+        result = db.one(query)
+        print("> Sent `%s` to SQLite, got `%s` as result" % (query, result))
 
     return db
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 libarchive-c
 lxml
-maps
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 libarchive-c
 lxml
+maps
 tqdm

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -94,7 +94,7 @@ def test_clean_html_does_not_collapse_spaces_inside_pre():
 def test_clean_html_escapes_properly():
     original = '<p attr="&quot;">&lt;p&gt;</p>'
     actual = clean_html(original)
-    expected = '''<p attr='"'>&lt;p&gt;</p>'''
+    expected = '''<p attr="&#34;">&lt;p&gt;</p>'''
     assert actual == expected
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -15,9 +15,9 @@ def test_clean_html_on_single_whitespace():
 
 
 def test_clean_html_collapses_spaces():
-    unclean = '<p>Lorem \r <b><i> ipsum</i> </b>\n\t dolor</p>'
+    unclean = '<s> Lorem \r <b><i> ipsum</i> dolor\n\t</b>sit </s>'
     cleaned = clean_html(unclean)
-    expected = '<p>Lorem <b><i>ipsum</i> </b>dolor</p>'
+    expected = '<s>Lorem <b><i>ipsum</i> dolor</b> sit</s>'
     assert cleaned == expected
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,40 @@
+# coding: utf8
+from __future__ import division, print_function, unicode_literals
+
+from legi.html import clean_html
+
+
+def test_clean_html_drops_empty_elements_and_text_nodes():
+    unclean = '''
+        <p>Lorem ipsum</p>
+        <p> <pre> </pre> </p>
+    '''
+    cleaned = clean_html(unclean)
+    expected = '<p>Lorem ipsum</p>'
+    assert cleaned == expected
+
+
+def test_clean_html_drops_useless_attributes_and_elements():
+    unclean = '''
+        <h1 align="center">Titre <font>1</font></h1>
+        <p id="foo"><span align="left"></span></p>
+    '''
+    cleaned = clean_html(unclean)
+    expected = '<h1 align="center">Titre 1</h1>'
+    assert cleaned == expected
+
+
+def test_clean_html_does_not_alter_clean_html():
+    expected = '<h1 align="center">Titre</h1><p>Lorem ipsum</p>'
+    actual = clean_html(expected)
+    assert actual == expected
+
+
+def test_clean_html_does_not_collapse_spaces_inside_pre():
+    unclean = '''
+        <pre>    print("Hello world")
+        </pre>
+    '''
+    actual = clean_html(unclean)
+    expected = unclean.strip()
+    assert actual == expected

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -25,14 +25,14 @@ def test_clean_html_drops_useless_attributes_and_elements():
 
 
 def test_clean_html_does_not_alter_clean_html():
-    expected = '<h1 align="center">Titre</h1><p>Lorem ipsum</p>'
+    expected = '<h1 align="center">Titre</h1><p>Lorem ipsum &amp;</p>'
     actual = clean_html(expected)
     assert actual == expected
 
 
 def test_clean_html_does_not_collapse_spaces_inside_pre():
     unclean = '''
-        <pre>    print("Hello world")
+        <pre>    print("&gt; Hello world")
         </pre>
     '''
     actual = clean_html(unclean)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -92,8 +92,9 @@ def test_clean_html_does_not_collapse_spaces_inside_pre():
 
 
 def test_clean_html_escapes_properly():
-    expected = '<p attr="&amp;">&lt;p&gt;</p>'
-    actual = clean_html(expected)
+    original = '<p attr="&quot;">&lt;p&gt;</p>'
+    actual = clean_html(original)
+    expected = '''<p attr='"'>&lt;p&gt;</p>'''
     assert actual == expected
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -4,6 +4,43 @@ from __future__ import division, print_function, unicode_literals
 from legi.html import clean_html
 
 
+def test_clean_html_on_empty_string():
+    r = clean_html('')
+    assert r == ''
+
+
+def test_clean_html_on_single_whitespace():
+    r = clean_html(' ')
+    assert r == ''
+
+
+def test_clean_html_collapses_spaces():
+    unclean = '<p>Lorem \r <b><i> ipsum</i> </b>\n\t dolor</p>'
+    cleaned = clean_html(unclean)
+    expected = '<p>Lorem <b><i>ipsum</i> </b>dolor</p>'
+    assert cleaned == expected
+
+
+def test_clean_html_drops_spaces_around_line_breaks():
+    # Basic
+    unclean = '<p>\t Lorem ipsum\n </p>'
+    cleaned = clean_html(unclean)
+    expected = '<p>Lorem ipsum</p>'
+    assert cleaned == expected
+    # Complex
+    unclean = '<p> <i> \nLorem <br/> ipsum\n </i> </p>'
+    cleaned = clean_html(unclean)
+    expected = '<p><i>Lorem<br/>ipsum</i></p>'
+    assert cleaned == expected
+
+
+def test_clean_html_drops_bad_spaces():
+    unclean = "L' <span>article 2</span>\n."
+    cleaned = clean_html(unclean)
+    expected = "L'article 2."
+    assert cleaned == expected
+
+
 def test_clean_html_drops_empty_elements_and_text_nodes():
     unclean = '''
         <p>Lorem ipsum</p>
@@ -11,6 +48,20 @@ def test_clean_html_drops_empty_elements_and_text_nodes():
     '''
     cleaned = clean_html(unclean)
     expected = '<p>Lorem ipsum</p>'
+    assert cleaned == expected
+
+
+def test_clean_html_drops_line_breaks_at_the_beginning():
+    unclean = ' <br/> <p> <br/> <br/> Text</p>'
+    cleaned = clean_html(unclean)
+    expected = '<p>Text</p>'
+    assert cleaned == expected
+
+
+def test_clean_html_does_not_drop_empty_table_cells():
+    unclean = '<tr><th></th><td> </td></tr><tr> </tr>'
+    cleaned = clean_html(unclean)
+    expected = '<tr><th/><td/></tr>'
     assert cleaned == expected
 
 
@@ -37,4 +88,16 @@ def test_clean_html_does_not_collapse_spaces_inside_pre():
     '''
     actual = clean_html(unclean)
     expected = unclean.strip()
+    assert actual == expected
+
+
+def test_clean_html_escapes_properly():
+    expected = '<p attr="&amp;">&lt;p&gt;</p>'
+    actual = clean_html(expected)
+    assert actual == expected
+
+
+def test_clean_html_preserves_attribute_order():
+    expected = '<h1 a="0" b="1" c="2" d="3" e="4">Titre</h1>'
+    actual = clean_html(expected)
     assert actual == expected

--- a/tests/test_innerHTML.py
+++ b/tests/test_innerHTML.py
@@ -1,0 +1,17 @@
+# coding: utf8
+from __future__ import division, print_function, unicode_literals
+
+from lxml import etree
+
+from legi.tar2sqlite import innerHTML
+
+
+def test_innerHTML():
+    el = etree.fromstring('<root></root>')
+    assert innerHTML(el) == ''
+    el = etree.fromstring('<root>text</root> ')
+    assert innerHTML(el) == 'text'
+    el = etree.fromstring('<root >text</root>')
+    assert innerHTML(el) == 'text'
+    el = etree.fromstring('<root attr="value"> </root>')
+    assert innerHTML(el) == ' '

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ skipsdist=True
 
 [testenv]
 commands=
+    pip install -q -r requirements.txt
     python -m pytest {toxinidir}/tests --cov legi --cov-report=term-missing {posargs}
     flake8 {toxinidir}
 deps=
-    -rrequirements.txt
     flake8
     pytest
     pytest-cov


### PR DESCRIPTION
Création d'un module `legi.html` permettant d'analyser et de nettoyer l'HTML fourni dans les archives LEGI.

Le nettoyeur supprime :

- les espaces redondantes (*whitespace collapse*), sauf à l'intérieur des `<pre>`
- les attributs inutiles, par exemple `id` et `dir="ltr"`
- les éléments inutiles, par exemple un `<span>` sans attributs
- les éléments vides, sauf `<td>` et `<th>`

Tout cela permet :

- de simplifier les expressions régulières (*regexp*) pour la détection des liens entre textes (#4)
- d'avoir une meilleure conversion vers Markdown
- d'alléger un peu la base de données
