### PR TITLE
[fix] Ajoute la creation du répertoire tarballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sous forme de paquet [sur PyPI][legi-pypi].
 La première étape est de télécharger les archives LEGI depuis
 `ftp://echanges.dila.gouv.fr/LEGI/`:
 
+    mkdir tarballs
     python -m legi.download ./tarballs
 
 La deuxième étape est la conversion des archives en base SQLite:


### PR DESCRIPTION
L'exécution linéaire de la documentation abouti à un file not found, ce qui pourrait rebuter des utilisateur peu familier de la chose technique.