### PR TITLE
Handle download errors, fall back to HTTPS when FTP fails, retry for up to 6 hours

### DIFF
--- a/cron/anomalies-cron.sh
+++ b/cron/anomalies-cron.sh
@@ -3,7 +3,7 @@
 set -o pipefail
 
 cd "$(dirname "$0")/.."
-python -u -m legi.download ./tarballs
+python -u -m legi.download -r ./tarballs
 echo "=> Starting tar2sqlite..."
 python -u -m legi.tar2sqlite legi.raw.sqlite tarballs --anomalies --anomalies-dir=anomalies --raw | tee -a legi.raw.log
 echo "=> Uploading anomaly logs..."

--- a/legi/download.py
+++ b/legi/download.py
@@ -15,6 +15,8 @@ DILA_LEGI_DIR = '/LEGI'
 
 
 def download_legi(dst_dir, retry_hours=0):
+    if not os.path.exists(dst_dir):
+        os.mkdir(dst_dir)
     sleep_hours = 0
     while True:
         try:
@@ -31,9 +33,7 @@ def download_legi(dst_dir, retry_hours=0):
 
 
 def download_legi_via_ftp(dst_dir):
-    if not os.path.exists(dst_dir):
-        os.mkdir(dst_dir)
-    local_files = {filename: {} for filename in os.listdir(dst_dir)}
+    local_files = set(os.listdir(dst_dir))
     ftph = ftplib.FTP()
     ftph.connect(DILA_FTP_HOST, DILA_FTP_PORT)
     ftph.login()
@@ -41,41 +41,20 @@ def download_legi_via_ftp(dst_dir):
     remote_files = [filename for filename in ftph.nlst() if '.tar.' in filename]
     common_files = [f for f in remote_files if f in local_files]
     missing_files = [f for f in remote_files if f not in local_files]
-    remote_files = {filename: {} for filename in remote_files}
-    for filename in common_files:
-        local_files[filename]['size'] = os.path.getsize(
-            os.path.join(dst_dir, filename)
-        )
     ftph.voidcmd('TYPE I')
-    for filename in remote_files:
-        file_size = ftph.size(filename)
-        remote_files[filename]['size'] = int(file_size)
-    invalid_files = []
-    for filename in common_files:
-        if local_files[filename]['size'] < remote_files[filename]['size']:
-            invalid_files.append(filename)
-    print(
-        '{} remote files, {} common files ({} invalid), {} missing files'
-        .format(
-            len(remote_files),
-            len(common_files), len(invalid_files),
-            len(missing_files)
-        )
-    )
-    for filename in invalid_files:
-        filepath = os.path.join(dst_dir, filename)
-        with open(filepath, mode='a+b') as fh:
-            print('Continuing the download of the file {}'.format(filename))
-            ftph.retrbinary(
-                'RETR {}'.format(filename),
-                fh.write,
-                rest=local_files[filename]['size']
-            )
+    print('{} remote files, {} common files, {} missing files'.format(
+        len(remote_files), len(common_files), len(missing_files),
+    ))
     for filename in missing_files:
         filepath = os.path.join(dst_dir, filename)
-        with open(filepath, mode='wb') as fh:
-            print('Downloading the file {}'.format(filename))
-            ftph.retrbinary('RETR {}'.format(filename), fh.write, rest=0)
+        with open(filepath + '.part', mode='a+b') as fh:
+            offset = fh.tell()
+            if offset:
+                print('Continuing the download of the file ' + filename)
+            else:
+                print('Downloading the file ' + filename)
+            ftph.retrbinary('RETR ' + filename, fh.write, rest=offset)
+        os.rename(filepath + '.part', filepath)
     ftph.quit()
 
 

--- a/legi/spelling.py
+++ b/legi/spelling.py
@@ -6,7 +6,6 @@ import os
 import re
 
 from appdirs import site_data_dir
-import hunspell
 
 from .roman import ROMAN_PATTERN_SIMPLE
 
@@ -27,6 +26,10 @@ class Spellchecker:
 
     def __init__(self, lang, filters=(), intra_word_chars=INTRA_WORD_CHARS):
         self.lang = lang
+        try:
+            import hunspell
+        except ImportError:
+            raise SpellcheckingIsUnavailable("the hunspell module is missing")
         paths = self._find_hunspell_files()
         if not paths:
             raise SpellcheckingIsUnavailable("the hunspell files for lang %r are missing" % lang)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ appdirs
 hunspell
 libarchive-c
 lxml
+requests
 tqdm


### PR DESCRIPTION
Avec ce patch j'espère améliorer le taux de réussite des mises à jours quotidiennes, qui n'est actuellement pas très bon car le téléchargement des archives LEGI échoue régulièrement.

~~Reste à ajouter le téléchargement via HTTP (#60) en alternative au FTP, pour améliorer encore plus le taux de réussite.~~