### PR TITLE
Using CyHunspell instead of PyHunspell which is not maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ en vigueur][tweet-texte-plus-ancien], etc.
 
 ## Installation
 
-legi.py a besoin de [`libarchive`][libarchive] et [`hunspell`][hunspell]. L'installation de ces dépendances varie selon le système d'exploitation :
+legi.py a besoin de [`libarchive`][libarchive] et d'un dictionnaire français au format d'[`hunspell`][hunspell]. L'installation de ces dépendances varie selon le système d'exploitation :
 
-- Arch Linux : `pacman -S --needed libarchive hunspell hunspell-fr`
+- Arch Linux : `pacman -S --needed libarchive hunspell-fr`
 - Mac OS X : la version de `libarchive` inclue dans Mac OS X est obsolète, vous pouvez utiliser [Homebrew](https://brew.sh/) pour installer une version récente en exécutant `brew install libarchive`, puis indiquer au module Python qu'il doit utiliser cette version en ajoutant une variable d'environnement : `export LIBARCHIVE="$(find "$(brew --cellar libarchive)" -name libarchive.13.dylib | sort | tail -1)"` (cette commande peut être ajoutée au fichier d'initialisation de votre shell, typiquement `~/.bashrc` ou `~/.zshrc`)
-- Ubuntu : `sudo apt-get install libarchive13 hunspell hunspell-fr libhunspell-dev`
+- Ubuntu : `sudo apt-get install libarchive13 hunspell-fr`
 
 Une fois ces dépendances système installées, vous pouvez cloner le dépôt et utiliser `pip` pour installer les modules python nécessaires :
 

--- a/legi/spelling.py
+++ b/legi/spelling.py
@@ -30,10 +30,10 @@ class Spellchecker:
             import hunspell
         except ImportError:
             raise SpellcheckingIsUnavailable("the hunspell module is missing")
-        paths = self._find_hunspell_files()
-        if not paths:
+        path = self._find_hunspell_files()
+        if not path:
             raise SpellcheckingIsUnavailable("the hunspell files for lang %r are missing" % lang)
-        self.dict = hunspell.HunSpell(*paths)
+        self.dict = hunspell.Hunspell(path)
         self.filters = filters
         self.intra_word_chars = set(intra_word_chars)
 
@@ -44,7 +44,7 @@ class Spellchecker:
             aff_path = os.path.join(base_dir, lang + '.aff')
             dic_path = os.path.join(base_dir, lang + '.dic')
             if os.path.exists(aff_path) and os.path.exists(dic_path):
-                return dic_path, aff_path
+                return os.path.join(base_dir, lang)
 
     def check(self, text):
         """Looks for misspelled words in `text`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appdirs
-hunspell
+cyhunspell
 libarchive-c
 lxml
 requests


### PR DESCRIPTION
PyHunspell is no longer maintained. CyHunspell is easy to install on all platforms (`pip install cyhunspell`) and actively maintained. The API is slightly changed: hunspell.Hunspell (instead of hunspell.HunSpell), and `.dic` and `.aff` are automatically appended to `path`, so no need to do so when returning from `_find_hunspell_files()`