### PR TITLE
Fix the detection of republican month names

### DIFF
--- a/legi/fr_calendar.py
+++ b/legi/fr_calendar.py
@@ -51,7 +51,7 @@ def convert_date_to_iso(jour, mois, annee):
     if not jour or not mois or not annee:
         return None, 'gregorian'
     jour = int(jour.lower().replace('1er', '1'))
-    if mois in MOIS_REPU_MAP:
+    if strip_down(mois) in MOIS_REPU_MAP:
         annee = strip_prefix(annee, 'an ')
         return republican_to_gregorian(annee, mois, jour).isoformat(), 'republican'
     else:


### PR DESCRIPTION
```python-traceback
Traceback (most recent call last):
  File "legi/tar2sqlite.py", line 575, in <module>
    main()
  File "legi/tar2sqlite.py", line 557, in main
    n_anomalies = detect_anomalies(db, f)
  File "legi/anomalies.py", line 233, in detect_anomalies
    anomalies_textes_versions(db, err)
  File "legi/anomalies.py", line 162, in anomalies_textes_versions
    d1, endpos1 = parse_titre(titre, anomaly_cb('titre'), strict=True)
  File "legi/titles.py", line 121, in parse_titre
    groups['date'], groups['calendar'] = convert_date_to_iso(
  File "legi/fr_calendar.py", line 58, in convert_date_to_iso
    mois = MOIS_GREG_MAP[strip_down(mois)]
KeyError: 'pluviose'
```