### PR TITLE
tar2sqlite: handle two unexpected shapes in recent DILA archives

### DIFF
--- a/legi/tar2sqlite.py
+++ b/legi/tar2sqlite.py
@@ -193,6 +193,7 @@ def process_archive(db, archive_path, raw, process_links=True, check_html=True):
     skipped = 0
     unknown_folders = {}
     liste_suppression = []
+    liste_suppression_dossier = []
     xml = etree.XMLParser(remove_blank_text=True)
     with tqdm(total=os.stat(archive_path).st_size, unit='bytes') as pbar, \
          open(archive_path, 'rb') as file, \
@@ -206,6 +207,24 @@ def process_archive(db, archive_path, raw, process_links=True, check_html=True):
             parts = path.split('/')
             if parts[-1] == 'liste_suppression_legi.dat':
                 liste_suppression += b''.join(entry.get_blocks()).decode('ascii').split()
+                continue
+            if parts[-1] == 'liste_suppression_legi_dossier.dat':
+                # Newer DILA archives ship a second deletion list, holding whole
+                # folders (a text and all its articles) as « path \n D » pairs.
+                # Applying those deletions is left for a follow-up: we only
+                # collect them here so they are reported rather than silently
+                # dropped -- and so the parsing below no longer crashes on a
+                # two-segment path.
+                liste_suppression_dossier += [
+                    line
+                    for line in b''.join(entry.get_blocks()).decode('ascii').split()
+                    if line != 'D'
+                ]
+                continue
+            if len(parts) < 3:
+                # Any other short path has nothing to offer, and `parts[2]`
+                # below would raise IndexError.
+                unknown_folders[path] = unknown_folders.get(path, 0) + 1
                 continue
             if parts[1] == 'legi':
                 path = path[len(parts[0])+1:]
@@ -302,7 +321,12 @@ def process_archive(db, archive_path, raw, process_links=True, check_html=True):
                 assert nature == 'Article'
                 assert table == 'articles'
                 contexte = root.find('CONTEXTE/TEXTE')
-                assert attr(contexte, 'cid') == row_cid
+                # DILA ships articles whose CONTEXTE/TEXTE carries no `cid`
+                # attribute. Its absence is not an inconsistency: the `cid`
+                # derived from the archive path is authoritative. Only compare
+                # when the attribute is actually there.
+                _cid_xml = attr(contexte, 'cid')
+                assert _cid_xml is None or _cid_xml == row_cid
                 sections = contexte.findall('.//TITRE_TM')
                 if sections:
                     attrs['section'] = attr(sections[-1], 'id')
@@ -314,7 +338,12 @@ def process_archive(db, archive_path, raw, process_links=True, check_html=True):
                 scrape_tags(attrs, root, SECTION_TA_TAGS)
                 section_id = row_id
                 contexte = root.find('CONTEXTE/TEXTE')
-                assert attr(contexte, 'cid') == row_cid
+                # DILA ships articles whose CONTEXTE/TEXTE carries no `cid`
+                # attribute. Its absence is not an inconsistency: the `cid`
+                # derived from the archive path is authoritative. Only compare
+                # when the attribute is actually there.
+                _cid_xml = attr(contexte, 'cid')
+                assert _cid_xml is None or _cid_xml == row_cid
                 parents = contexte.findall('.//TITRE_TM')
                 if parents:
                     attrs['parent'] = attr(parents[-1], 'id')
@@ -469,6 +498,9 @@ def process_archive(db, archive_path, raw, process_links=True, check_html=True):
 
     if liste_suppression:
         suppress(get_table, db, liste_suppression)
+    if liste_suppression_dossier:
+        print("  NOTE:", len(liste_suppression_dossier),
+              "folder(s) flagged for deletion by DILA, not applied")
 
     if not raw:
         remove_detected_soft_hyphens(db, soft_hyphens)


### PR DESCRIPTION
`tar2sqlite` ne parvient plus à traiter les dumps LEGI que DILA publie
aujourd'hui. Deux problèmes distincts, tous deux reproductibles depuis un clone
neuf.

## 1. `AssertionError` — attribut `cid` absent

Le traitement s'arrête à environ 0,26 % du dump global actuel
(`Freemium_legi_global_20250713-140000.tar.gz`) :

```
File "legi/tar2sqlite.py", line 305, in process_archive
    assert attr(contexte, 'cid') == row_cid
AssertionError
```

En instrumentant l'assertion :

```
article     LEGIARTI000006433126
cid (chemin) JORFTEXT000000722513
cid (XML)    None
```

Certains articles ne portent tout simplement pas d'attribut `cid` sur
`CONTEXTE/TEXTE` — typiquement ceux rattachés à un texte JORF plutôt qu'à un
code. `attr()` renvoie `None` et l'égalité échoue.

Cette absence n'est pas une incohérence : le `cid` déduit du chemin d'archive
fait foi et sert déjà partout ailleurs. Le correctif conserve la vérification
quand l'attribut est présent et tolère son absence. Deux occurrences, `ARTICLE`
et `SECTION_TA`.

## 2. `IndexError` — `liste_suppression_legi_dossier.dat` inconnu

Une fois le premier problème corrigé, le traitement passe le dump global et
204 diffs quotidiens, puis s'arrête sur celui du 5 février 2026 :

```
File "legi/tar2sqlite.py", line 213, in process_archive
    if not parts[2].startswith('code_et_TNC_'):
IndexError: list index out of range
```

Les archives récentes embarquent une seconde liste de suppression à la racine :

```
20260205-212615/liste_suppression_legi.dat           ← reconnue
20260205-212615/liste_suppression_legi_dossier.dat   ← inconnue
```

Le fichier inconnu échoue au premier test de nom, puis atteint `parts[2]` sur un
chemin à deux segments.

**Ce fichier n'est pas cosmétique.** Il liste des dossiers entiers à supprimer —
un texte et tous ses articles — sous forme de paires `chemin \n D` :

```
legi/global/code_et_TNC_en_vigueur/TNC_en_vigueur/JORF/TEXT/.../JORFTEXT000050099708
D
```

Donc au-delà du plantage, `legi.py` **conserve actuellement des textes que DILA a
retirés**.

Cette PR s'arrête volontairement avant d'appliquer ces suppressions : effacer des
données est une décision distincte, et vous êtes mieux placés que moi pour la
prendre. Elle reconnaît le fichier, collecte les entrées et en signale le nombre,
de sorte que l'information remonte au lieu d'être perdue en silence. Un garde-fou
sur la longueur est ajouté pour que tout autre chemin court soit compté comme
dossier inconnu plutôt que de tout interrompre.

Je veux bien enchaîner sur la suppression effective des dossiers si vous estimez
que cela relève de la bibliothèque — je préfère demander plutôt que supprimer des
lignes à la place de vos utilisateurs.

## Vérification

Base construite à partir du dump global du 13/07/2025 et des 388 diffs
quotidiens jusqu'au 02/08/2026 :

```
articles          1 817 657
textes_versions     152 742
textes              147 865
sections            246 867
liens             8 937 310
sommaires         2 255 921
last_update      20260802-212422
```

Aucune erreur. 662 dossiers ont été marqués pour suppression sur 121 archives —
le décompte que remonte la nouvelle ligne `NOTE`.

## Reproduction

```
python -m legi.download tarballs/
python -m legi.tar2sqlite legi.sqlite tarballs/
```
